### PR TITLE
A few improvements

### DIFF
--- a/ALARM/Build/Service.pm
+++ b/ALARM/Build/Service.pm
@@ -531,10 +531,12 @@ sub _cb_error {
             if (defined $self->{clients}->{$handle}->{file}) {      # close out file if it's open
                 close $self->{clients}->{$handle}->{file};
             }
-            if ($self->{clients}->{$handle}->{ou} eq "builder" && $self->{clients}->{$handle}->{state} eq "building") {
-                print "   -> releasing package: $self->{clients}->{$handle}->{cn} ($self->{clients}->{$handle}->{arch}) $self->{clients}->{$handle}->{pkgbase}\n";
-                $q_irc->enqueue(['svc', 'privmsg', "[released] $self->{clients}->{$handle}->{cn} ($self->{clients}->{$handle}->{arch}) $self->{clients}->{$handle}->{pkgbase}"]);
-                $q_db->enqueue(['svc', 'pkg_release', $self->{clients}->{$handle}->{arch}, $self->{clients}->{$handle}->{cn}, { arch => $self->{clients}->{$handle}->{arch}, pkgbase => $self->{clients}->{$handle}->{pkgbase} }]);
+            if (defined $self->{clients}->{$handle}->{state}) {
+                if ($self->{clients}->{$handle}->{ou} eq "builder" && $self->{clients}->{$handle}->{state} eq "building") {
+                    print "   -> releasing package: $self->{clients}->{$handle}->{cn} ($self->{clients}->{$handle}->{arch}) $self->{clients}->{$handle}->{pkgbase}\n";
+                    $q_irc->enqueue(['svc', 'privmsg', "[released] $self->{clients}->{$handle}->{cn} ($self->{clients}->{$handle}->{arch}) $self->{clients}->{$handle}->{pkgbase}"]);
+                    $q_db->enqueue(['svc', 'pkg_release', $self->{clients}->{$handle}->{arch}, $self->{clients}->{$handle}->{cn}, { arch => $self->{clients}->{$handle}->{arch}, pkgbase => $self->{clients}->{$handle}->{pkgbase} }]);
+                }
             }
             delete $self->{clientsref}->{"$self->{clients}->{$handle}->{ou}/$self->{clients}->{$handle}->{cn}"};
         }

--- a/client.conf
+++ b/client.conf
@@ -2,7 +2,7 @@
 # plugbuild server to connect to
 server      = "archlinuxarm.org"
 port        = 2121
-workurl     = "/builder/work"
+workurl     = "http://archlinuxarm.org/builder/work"
 
 # farmer incoming package rsync
 farmer      = 1.2.3.4::incoming

--- a/client.pl
+++ b/client.pl
@@ -20,7 +20,7 @@ my %config = ParseConfig("$Bin/client.conf");
 my $workroot    = "$Bin/work";
 my $pkgdest     = "$Bin/pkgdest";
 my $cacheroot   = "$Bin/cache";
-my $workurl     = "http://$config{server}$config{workurl}";
+my $workurl     = "$config{workurl}";
 
 my $md5 = hash_script();
 


### PR DESCRIPTION
# Changes
- The building state isn't set in the `_cb_error` function when a `duplicate client` error occurs, so a check has been added to ensure it's been defined before performing that portion of the check.
- Set the `workurl` in client.pl using the full URL to allow for alternative ports and/or ipv6.
